### PR TITLE
Ora il dizionato selezionato comparirà in verde. Closes #46 closes #50

### DIFF
--- a/backend/chatsql/adapter/outcoming/persistance/JSONRepositoryAdapter.py
+++ b/backend/chatsql/adapter/outcoming/persistance/JSONRepositoryAdapter.py
@@ -4,21 +4,21 @@ from chatsql.application.port.outcoming.persistance.BaseJSONRepository import Ba
 
 from chatsql.utils.JSONValidator import JSONValidator
 
+from chatsql.utils.Common import Settings
 from chatsql.utils import Exceptions
 
 import json
-from os import listdir, remove
-from os.path import isfile, join
+from os import listdir, remove, mkdir
+from os.path import isfile, join, exists
 
 from shutil import copyfileobj
 from werkzeug.utils import secure_filename
-import os
 
 class JSONRepositoryAdapter(BaseJsonRepository):
 
     def __init__(self) -> None:
         
-        self._folder = 'uploads'
+        self._folder = Settings.folder
         self.__create_folder()
 
 
@@ -74,6 +74,6 @@ class JSONRepositoryAdapter(BaseJsonRepository):
         return secured_filename in self.list_all()
 
     def __create_folder(self) -> bool:
-        if not os.path.exists(self._folder):
-            os.mkdir(self._folder)
+        if not exists(self._folder):
+            mkdir(self._folder)
 

--- a/backend/chatsql/application/JSONManagerService.py
+++ b/backend/chatsql/application/JSONManagerService.py
@@ -13,8 +13,7 @@ class JSONManagerService(
     InserimentoDizionarioUseCase,
     EliminazioneDizionarioUseCase,
     VisualizzaListaDizionariUseCase,
-    VisualizzaDizionarioCorrenteUseCase,
-    LoadDizionarioUseCase
+    VisualizzaDizionarioCorrenteUseCase
 ):
     
     def __init__(self, jsonRepository: BaseJsonRepository) -> None:
@@ -40,6 +39,11 @@ class JSONManagerService(
             raise ValueError(f"`{filename}` non esistente")
         return True
 
+    @property
     def selected(self) -> str:
         return self._selectedFile
+    
+    @selected.setter
+    def selected(self, filename: str) -> None:
+        self._selectedFile = filename
     

--- a/backend/chatsql/application/port/incoming/VisualizzaDizionarioCorrenteUseCase.py
+++ b/backend/chatsql/application/port/incoming/VisualizzaDizionarioCorrenteUseCase.py
@@ -3,7 +3,13 @@ from abc import ABC, abstractmethod
 
 class VisualizzaDizionarioCorrenteUseCase(ABC):
 
+    @property
     @abstractmethod
     def selected(self) -> str:
+        pass
+
+    @selected.setter
+    @abstractmethod
+    def selected(self, filename: str) -> None:
         pass
     

--- a/backend/chatsql/utils/Common.py
+++ b/backend/chatsql/utils/Common.py
@@ -1,0 +1,5 @@
+from dataclasses import dataclass
+
+@dataclass
+class Settings:
+    folder: str = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ from chatsql.adapter.outcoming.persistance.JSONRepositoryAdapter import JSONRepo
 
 from chatsql.application.JSONManagerService import JSONManagerService
 
+from chatsql.utils.Common import Settings
 import os
 
 app = Flask(__name__, static_url_path='', template_folder='../frontend/src/views')
@@ -18,7 +19,7 @@ def heartbeat():
 
 if __name__ == '__main__':
 
-    uploads_folder = os.path.join(os.getcwd(), 'uploads')
+    Settings.folder = os.path.join(os.environ['TEMP'], 'uploads')
 
     jsonRepository = JSONRepositoryAdapter()
     
@@ -29,7 +30,6 @@ if __name__ == '__main__':
         eliminazioneDizionarioUseCase=jsonService,
         visualizzaListaDizionariUseCase=jsonService,
         visualizzaDizionarioCorrenteUseCase=jsonService,
-        loadDizionarioUseCase=jsonService
     )
 
 

--- a/frontend/src/components/LoadButton.vue
+++ b/frontend/src/components/LoadButton.vue
@@ -12,11 +12,11 @@ export default {
    * Component for a load button.
    *
    * @props {String} LoadButtonClass - The CSS class for the load button.
-   * @props {String} id - The unique identifier for the load button.
+   * @props {String} filename - The name of the file to be loaded.
    */
   props: {
     LoadButtonClass: String,
-    id: String
+    filename: String 
   },
   /**
    * Sets up the component and defines the loadDictionary function.
@@ -29,12 +29,12 @@ export default {
   setup(props, { emit }) {
 
     /**
-     * Loads the dictionary by emitting a 'load-click' event with the provided ID.
+     * Loads the dictionary by emitting a 'load-click' event with the provided filename.
      *
-     * @param {number} id - The ID of the dictionary to load.
+     * @param {String} filename - The filename of the dictionary to load.
      */
     function loadDictionary() {
-      emit('load-click', props.id);
+      emit('load-click', props.filename);
     }
 
     return {

--- a/frontend/src/components/ViewDictionary.vue
+++ b/frontend/src/components/ViewDictionary.vue
@@ -33,7 +33,7 @@
           <td>{{entry.date}}</td>
           <td>{{entry.size}}</td>
           <td>
-            <LoadButton :id="entry.id" :name="entry.name" :class="loadButtonClass" @load-click="loadButtonClick(entry.id)" />
+            <LoadButton :id="entry.id" :name="entry.name" :class="loadButtonClass" @load-click="loadButtonClick(entry.name + '.' + entry.extension)" />
             <DeleteButton :id="entry.id" :name="entry.name" :class="deleteButtonClass" @delete-click="deleteButtonClick(entry.id)" />
           </td>
         </tr>

--- a/frontend/src/model/MManager.js
+++ b/frontend/src/model/MManager.js
@@ -112,9 +112,15 @@ export default {
    * @param {number} index - The index of the dictionary to load.
    * @returns {Promise<Boolean>} - A promise that resolves with the loaded dictionary data, or false if the loading fails.
    */
-  async loadDictionary(index) {
+  async loadDictionary(filename) {
     try {
-      const response = await axios.post('http://localhost:5000/load', { data: index });
+      const formData = new FormData();
+      formData.append('selected', filename);
+      const response = await axios.post('http://localhost:5000/select', formData, {
+        headers: {
+          'Content-Type': 'multipart/form-data'
+        }
+      });
       console.log('Backend response status:', response.status);  
       if (response.status === 200) {
         return true; 

--- a/frontend/src/viewmodel/VMManager.js
+++ b/frontend/src/viewmodel/VMManager.js
@@ -70,9 +70,9 @@ const VMManager = {
    * @param {number} id - The ID of the dictionary to load.
    * @returns {Promise<void>} - A promise that resolves when the dictionary is loaded.
    */
-  async handleLoadDictionary(id) 
+  async handleLoadDictionary(filename) 
   {
-    const response = await MManager.loadDictionary(id);
+    const response = await MManager.loadDictionary(filename);
     if (!response) 
     {
       vueComponent.setToastMessage('Internal Server Error');

--- a/frontend/src/views/ManagerPage.vue
+++ b/frontend/src/views/ManagerPage.vue
@@ -64,8 +64,8 @@ export default {
      *
      * @param {number} index - The index of the dictionary to load.
      */
-    handleLoadButton(index) {
-      VMManager.handleLoadDictionary(index);
+    handleLoadButton(filename) {
+      VMManager.handleLoadDictionary(filename);
     },
 
     /**


### PR DESCRIPTION
Il frontend è stato modificato in modo da ritornare il filename del dizionario e non l'id della tabella.
<br>
Questa PR porta con sé modifiche architetturali: 
- è stata aggiornata l'interfaccia `VisualizzaDizionarioCorrenteUseCase`
- `JSONManagerService` non sarà più il responsabile del caricamento degli embeddings. Tale responsabilità passa a `RichiestaPromptService`.

Vedere il diagramma delle classi per una rappresentazione visuale.

